### PR TITLE
eliminated vizlab.clicklink use in favor of local function that sends…

### DIFF
--- a/layout/js/animate.js
+++ b/layout/js/animate.js
@@ -127,10 +127,11 @@ function cursorPoint(evt){
 function openNWIS(id, event){
  if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ) {
    event.stopPropagation();
-}else{
-   vizlab.clicklink('http://waterdata.usgs.gov/nwis/uv?site_no='+id,'_blank');
+  }else{
+    url = 'http://waterdata.usgs.gov/nwis/uv?site_no=' + id;
+    ga('send', 'event', 'outbound', 'click', url);
+    window.open(url, '_blank');
   }
-  
 }
 
 function setBold(id){


### PR DESCRIPTION
… the google analytics event and opens the url in a new tab.

Fix for https://github.com/USGS-VIZLAB/hurricane-irma/issues/71