### PR TITLE
button won't block hovers when animation is playing

### DIFF
--- a/layout/css/map-figure.css
+++ b/layout/css/map-figure.css
@@ -46,12 +46,13 @@ figurecaption{
 }
 
 #playButton{
-  background:#003366;
+  background:rgb(0,51,102);
+  background:rgba(0,51,102,.4);
   position: absolute;
   margin: auto;
   text-align: center;
   left:0; right:0;
-  top:25%;
+  top:0; bottom:0;
   height:75px;
   width:75px;
   border-radius:45px;
@@ -67,7 +68,7 @@ figurecaption{
 }
 
 
-#map-figure{
+#figureButtonCenter{
   position: relative;
 }
 
@@ -77,10 +78,6 @@ figurecaption{
     width:760px;
     margin:10px auto 10px auto;
     font-size:1em;
-  }
-  
-  #playButton{
-    top:40%;
   }
 }
 

--- a/layout/js/animate.js
+++ b/layout/js/animate.js
@@ -43,12 +43,12 @@ var playPause = function() {
   if (running) {
     clearInterval(interval);
     running = false;
-    button.css('opacity', '.4');
+    button.css('display', 'block');
     ga('send', 'event', 'figure', 'user pressed pause');
   } else {
     running = true;
     ga('send', 'event', 'figure', 'user pressed play');
-    button.css('opacity', '0');
+    button.css('display', 'none');
     interval = setInterval(function() {
       if (timestep < prcpTimes.times.length) {
         animatePrcp(timestep);
@@ -57,7 +57,7 @@ var playPause = function() {
         timestep = 1;
         clearInterval(interval);
         running = false;
-        button.css('opacity', '.4');
+        button.css('display', 'block');
       }
     }, intervalLength);
   }

--- a/layout/templates/mapFigure.mustache
+++ b/layout/templates/mapFigure.mustache
@@ -1,12 +1,13 @@
 <div id="{{id}}" caption="Precipitation from Hurricane Irma">
-  <figure>
-    {{{figure}}}
-  </figure>
-  
-  <button id="playButton" onclick="playPause();">
-    {{{playIcon}}}
-  </button>
-  
+  <div id="figureButtonCenter">
+    <figure>
+      {{{figure}}}
+    </figure>
+    <button id="playButton" onclick="playPause();">
+      {{{playIcon}}}
+    </button>
+  </div>
+
   <figureCaption>
     {{line1}}
     <a href="{{stnLink}}" rel = "external" onclick="vizlab.clicklink('{{stnLink}}'); return false;">{{stnText}}</a>


### PR DESCRIPTION
Button goes display none when the animation is playing, so no longer blocks hovers by users.

Added a div around the figure to allow more precise centering of the play button, as it will center based on the figures height rather than the map-figure height, which also contains the figure text and throws the button seemingly out of whack.