### PR TITLE
Thumb landing

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -25,7 +25,7 @@ info:
     height: 300
     alttext: "Hurricane Irma"
   thumbnail-landing:
-    url: https://owi.usgs.gov/vizlab/hurricane-irma/images/thumb-landing.png
+    url: images/thumb-landing.png
     width: 400
     height: 400
     alttext: "Hurricane Irma"


### PR DESCRIPTION
A relative file path is needed for vizlab landing page. A future vizlab change will fix it so that each thumbnail path requirement (relative vs full) will be the same.