### PR TITLE
prcpdata undefined when running on windows

### DIFF
--- a/layout/js/animate.js
+++ b/layout/js/animate.js
@@ -22,10 +22,10 @@ var fetchSvg = $.ajax({
 });
 
 var fetchPrcpColors = $.get("js/precip-colors.json").done(function(data) {
-  prcpColors = data;
+  prcpColors = JSON.parse(data);
 });
 var fetchPrcpTimes = $.get("js/times.json").done(function(data) {
-  prcpTimes = data;
+  prcpTimes = JSON.parse(data);
 });
 
 var animatePrcp = function(timestep, $currentStormDot) {


### PR DESCRIPTION
I had this issue Tuesday when setting up and running locally. I believe Lindsay has experienced this too. 

prcpTime and prcpColor data objects are represented as string types after `$.get` callbacks on Windows for some reason. This makes calls like `prcpTime.times.length` undefined. 

Simple fix is just to cast back to JSON object. 